### PR TITLE
Moved chown to the end of the file to be sure all files created in previ...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,6 @@ RUN curl --silent --output fabric8.zip https://repository.jboss.org/nexus/conten
 RUN unzip -q fabric8.zip 
 RUN mv fabric8-karaf-1.0.0.redhat-366 fabric8
 RUN rm fabric8.zip
-RUN chown -R fuse:fuse fabric8
 
 WORKDIR /home/fuse/fabric8/etc
 
@@ -59,6 +58,8 @@ RUN echo >> data/log/karaf.log
 
 RUN curl --silent --output startup.sh https://raw.github.com/fabric8io/fabric8-docker/master/startup.sh
 RUN chmod +x startup.sh
+
+RUN chown -R fuse:fuse .
 
 EXPOSE 22 1099 2181 8101 8181 9300 9301 44444 61616 
 


### PR DESCRIPTION
...ous steps are now assigned to Fuse user

And on top of that, with recent refactoring to Centos image a better strategy to users diversification need to be planned:
- current image creates a `fuse` user and relabel the filesystem to be owned by him, but the startup script is still running as `root`. In this way, all new files created by the runtime are owned by `root` which is possibly not wanted.
