### PR TITLE
General tidy up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-FROM fedora
+FROM debian:stable
 
-# telnet is required by some fabric command. without it you have silent failures
-RUN yum install -y java-1.7.0-openjdk unzip
+RUN apt-get update && apt-get install -y --no-install-recommends openjdk-7-jre-headless tar curl && apt-get autoremove -y && apt-get clean
 
 #set the fabric8 version env variable
 ENV FABRIC8_DISTRO_VERSION 1.2.0.Beta2
 
-# Clean the metadata
-RUN yum clean all
-
-ENV JAVA_HOME /usr/lib/jvm/jre
+ENV JAVA_HOME /usr/lib/jvm/java-1.7.0-openjdk-amd64
 
 ENV FABRIC8_RUNTIME_ID root
 ENV FABRIC8_KARAF_NAME root
@@ -19,28 +15,17 @@ ENV FABRIC8_HTTP_PORT 8181
 ENV FABRIC8_HTTP_PROXY_PORT 8181
 
 # add a user for the application, with sudo permissions
-RUN useradd -m fabric8 ; echo fabric8: | chpasswd ; usermod -a -G wheel fabric8
-
-# command line goodies
-RUN echo "export JAVA_HOME=/usr/lib/jvm/jre" >> /etc/profile
-RUN echo "alias ll='ls -l --color=auto'" >> /etc/profile
-RUN echo "alias grep='grep --color=auto'" >> /etc/profile
-
-
-WORKDIR /home/fabric8
+RUN useradd -m fabric8
 
 ADD startup.sh /home/fabric8/startup.sh
-RUN chmod +x startup.sh
 
 USER fabric8
 
 # temporarily use the jboss nexus while the release syncs
-RUN curl --silent --output fabric8.zip http://central.maven.org/maven2/io/fabric8/fabric8-karaf/$FABRIC8_DISTRO_VERSION/fabric8-karaf-$FABRIC8_DISTRO_VERSION.zip
-RUN unzip -q fabric8.zip 
-RUN ls -al
-RUN mv fabric8-karaf-$FABRIC8_DISTRO_VERSION fabric8-karaf
-RUN rm fabric8.zip
-#RUN chown -R fabric8:fabric8 fabric8-karaf
+RUN cd /home/fabric8 && \
+    curl --silent https://repo1.maven.org/maven2/io/fabric8/fabric8-karaf/$FABRIC8_DISTRO_VERSION/fabric8-karaf-$FABRIC8_DISTRO_VERSION.tar.gz | tar xz && \
+    mv fabric8-karaf-$FABRIC8_DISTRO_VERSION fabric8-karaf && \
+    chown -R fabric8:fabric8 fabric8-karaf
 
 # temporary fix for docker issue until 1.2.0.Beta3
 ADD jetty.xml /home/fabric8/fabric8-karaf/fabric/import/fabric/profiles/default.profile/jetty.xml
@@ -56,26 +41,13 @@ RUN echo fabric.environment=docker >> system.properties
 RUN echo zookeeper.password.encode=true >> system.properties
 
 # lets remove the karaf.delay.console=true to disable the progress bar
-RUN sed -i '/karaf.delay.console=true/d' config.properties 
-RUN echo karaf.delay.console=false >> config.properties
-
-# lets add a user - should ideally come from env vars?
-RUN echo >> users.properties 
-RUN echo admin=admin,admin >> users.properties 
+RUN sed -i 's/karaf.delay.console=true/karaf.delay.console=false/' config.properties 
 
 # lets enable logging to standard out
-RUN echo log4j.rootLogger=INFO, stdout, osgi:* >> org.ops4j.pax.logging.cfg 
+RUN sed -i 's/log4j.rootLogger=INFO, out, osgi:*/log4j.rootLogger=INFO, stdout, osgi:*/' org.ops4j.pax.logging.cfg
 
 WORKDIR /home/fabric8/fabric8-karaf
 
-# ensure we have a log file to tail 
-RUN mkdir -p data/log
-RUN echo >> data/log/karaf.log
-
-WORKDIR /home/fabric8
-
-EXPOSE 1099 2181 8101 8181 9300 9301 44444 61616 
-
-USER root
+EXPOSE 1099 2181 8101 8181 9300 9301 44444 61616
 
 CMD /home/fabric8/startup.sh

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ If you have docker installed you should be able to try it out via
 
 You can pass in various [environment variables](http://fabric8.io/#/site/book/doc/index.md?chapter=environmentVariables_md) to customise how a fabric is created or joined; or specify stand alone mode if required etc.
 
+In addition, the Docker image allows you to override a few other things through environment variables:
+
+* `ADMIN_USERNAME`: the admin username you can use to connect to the Karaf shell as & authenticate to HawtIO (default: `admin`)
+* `ADMIN_PASSWORD`: the admin password to use (default: `admin`)
+* `DOCKER_HOST`: the URI to the Docker REST endpoint. This is necessary if you want to manage Docker containers from your Docker container :) (default: `tcp://172.17.42.1:4243`)
+
 If you are on OS X then see [How to use Docker on OS X](DockerOnOSX.md).
 
 e.g. to startup 5 Fabric8 instances; each will get their own IP address etc:

--- a/startup.sh
+++ b/startup.sh
@@ -6,8 +6,12 @@ echo Starting Fabric8 container ID: $FABRIC8_RUNTIME_ID
 echo Connecting to ZooKeeper: $FABRIC8_ZOOKEEPER_URL using environment: $FABRIC8_FABRIC_ENVIRONMENT
 echo Using bindaddress: $FABRIC8_BINDADDRESS
 
-# TODO if enabled should we tail the karaf log to work nicer with docker logs?
-#tail -f /home/fabric8/data/log/karaf.log
+ADMIN_USERNAME=${ADMIN_USERNAME:-admin}
+ADMIN_PASSWORD=${ADMIN_PASSWORD:-admin}
 
-#sudo -u fabric8 /home/fabric8/fabric8-karaf/bin/fabric8 server
-/home/fabric8/fabric8-karaf/bin/fabric8 server
+echo "admin=${ADMIN_USERNAME},${ADMIN_PASSWORD}" >> users.properties
+
+export DOCKER_HOST=${DOCKER_HOST:-tcp://172.17.42.1:4243}
+
+# Use exec to replace shell with process to ensure signals get handled correctly
+exec /home/fabric8/fabric8-karaf/bin/fabric8 server


### PR DESCRIPTION
- Shrink image by using Debian base image (reduces size from 1.2GB to
  360MB)
- Switch to using Fabric8 user (only uses non-privileged ports now)
- Specify admin user/password through env variables
- Logs to stdout
