### PR TITLE
configure karaf.name/runtime.id from docker env, and fix users.properties

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,6 @@ RUN chown -R fabric8:fabric8 /opt/fabric8 /opt/fabric8/startup.sh /opt/fabric8-k
 # so for now lets just run as root
 #USER fabric8
 
-# lets remove the karaf.name by default so we can default it from env vars
-RUN sed -i '/karaf.name=root/d' /opt/fabric8/etc/system.properties 
-RUN sed -i '/runtime.id=/d' /opt/fabric8/etc/system.properties 
-
 RUN echo bind.address=0.0.0.0 >> /opt/fabric8/etc/system.properties
 RUN echo fabric.environment=docker >> /opt/fabric8/etc/system.properties
 RUN echo zookeeper.password.encode=true >> /opt/fabric8/etc/system.properties

--- a/startup.sh
+++ b/startup.sh
@@ -12,7 +12,11 @@ echo Connecting to ZooKeeper:       $FABRIC8_ZOOKEEPER_URL
 echo Environment:                   $FABRIC8_FABRIC_ENVIRONMENT
 echo Using bindaddress:             $FABRIC8_BINDADDRESS
 
-echo "admin=${ADMIN_USERNAME},${ADMIN_PASSWORD}" >> users.properties
+grep -q "${ADMIN_USERNAME}=${ADMIN_PASSWORD},admin,manager,viewer" /opt/fabric8/etc/users.properties || echo "${ADMIN_USERNAME}=${ADMIN_PASSWORD},admin,manager,viewer" >> /opt/fabric8/etc/users.properties
+
+# lets base the karaf.name on the configured environment variable.
+sed -i "s/^karaf.name=root$/karaf.name=${FABRIC8_RUNTIME_ID}/" /opt/fabric8/etc/system.properties
+
 
 # Use exec to replace shell with process to ensure signals get handled correctly
 exec /opt/fabric8/bin/fabric8 server


### PR DESCRIPTION
In the docker fabric8 instance root container, I was unable to add the insight-console profile due to:
can't create ES node: "Could not resolve placeholder 'runtime.id'"

this was caused by the Dockerfile deleting the karaf.name and runtime.id from etc/system.properties

I changed the Dockerfile and startup.sh to replace the setting based on the environment variable instead of deleting the settings from the Dockerfile.
Also changed the user.properties modification, which seemed erroneous. 
